### PR TITLE
Added 30hz lowpass filter for oddball pipeline

### DIFF
--- a/src/cli/runners/oddball.py
+++ b/src/cli/runners/oddball.py
@@ -88,6 +88,8 @@ def run(
                         timestamp=timestamp,
                     )
                 )
+                if "{timestamp}" not in config.REPORT_DIR_TEMPLATE:
+                    out_dir = out_dir / timestamp
                 out_path = out_dir / "oddball_qc.html"
 
                 html_fragments: list[str] = []

--- a/src/pipelines/p300_oddball.py
+++ b/src/pipelines/p300_oddball.py
@@ -45,6 +45,13 @@ ERP_CONFIG = {
     "mmn_expected_electrodes": ["Fz", "Cz"],
 }
 
+ODDBALL_FILTER_CONFIG = {
+    # Temporarily using 60 Hz notch only so we can judge its isolated effect on oddball outputs.
+    "notch_freq_hz": 60.0,
+    "lowpass_freq_hz": None,
+    "filter_method": "iir",
+}
+
 # Event labels used for standard (frequent) stimuli in the oddball paradigm.
 STANDARD_EVENT_LABELS = {"standard", "frequent"}
 
@@ -243,7 +250,7 @@ class P300OddballPipeline(BasePipeline):
                 )
                 self._last_epoch_diagnostics = mapping_diag
 
-                epochs = self._extract_subepochs(epochs35, rare_mapped_df)
+                epochs = self._apply_official_filters(self._extract_subepochs(epochs35, rare_mapped_df))
 
                 if len(epochs) < ERP_CONFIG["min_epochs"]:
                     logger.warning(
@@ -257,6 +264,7 @@ class P300OddballPipeline(BasePipeline):
                 standard_erp = None
                 standard_sem = None
                 diff_erp = None
+                standard_epochs = None
                 n_standard_epochs = 0
                 n_standard_events_candidate = len(standard_events)
 
@@ -266,7 +274,7 @@ class P300OddballPipeline(BasePipeline):
                         trial_windows,
                         sfreq=float(epochs35.info["sfreq"]),
                     )
-                    standard_epochs = self._extract_subepochs(epochs35, std_mapped_df)
+                    standard_epochs = self._apply_official_filters(self._extract_subepochs(epochs35, std_mapped_df))
                     n_standard_epochs = len(standard_epochs)
 
                     if n_standard_epochs >= ERP_CONFIG["min_epochs"]:
@@ -331,9 +339,13 @@ class P300OddballPipeline(BasePipeline):
                 # Merge significance statistics into feature dict
                 features.update(p300_sig)
 
-                rows.append(features)
+                self._generate_session_plots(
+                    patient_id=self.patient_id or "",
+                    session_id=session_id,
+                    session=sess,
+                    features=features,
+                )
 
-                # Persist ERPs and features
                 self._save_outputs(
                     patient_id=self.patient_id or "",
                     session_id=session_id,
@@ -344,49 +356,10 @@ class P300OddballPipeline(BasePipeline):
                     diff_erp=sess.diff_erp,
                 )
 
-                # Generate and save plots via OddballVisualizer
-                sid = self._sanitize_session_id(session_id)
-                label = f"{self.patient_id or ''} | {session_id}" + (f" ({sess.date})" if sess.date else "")
-
-                fig_erp = self.viz.plot_erp_figure(
-                    sess.rare_erp,
-                    sess.rare_sem,
-                    sess.standard_erp,
-                    sess.standard_sem,
-                    sess.diff_erp,
-                    features,
-                    label,
-                )
-                self._save_fig(fig_erp, self._output_paths.plots_erp / f"{self.patient_id}_{sid}_oddball_erp.png")
-
-                fig_img = self.viz.plot_erp_image(sess.epochs, label)
-                if fig_img is not None:
-                    self._save_fig(
-                        fig_img,
-                        self._output_paths.plots_erp / f"{self.patient_id}_{sid}_oddball_erp_image.png",
-                    )
-
-                if sess.diff_erp is not None:
-                    fig_topo = self.viz.plot_topomap(sess.diff_erp, label)
-                    self._save_fig(
-                        fig_topo,
-                        self._output_paths.plots_erp / f"{self.patient_id}_{sid}_oddball_topomap.png",
-                    )
-
-                    anim_topo = self.viz.animate_topomap(sess.diff_erp, label)
-                    if anim_topo:
-                        gif_path = self._output_paths.plots_erp / f"{self.patient_id}_{sid}_oddball_topomap.gif"
-                        # anim_topo is a list of PIL frames
-                        anim_topo[0].save(
-                            gif_path,
-                            save_all=True,
-                            append_images=anim_topo[1:],
-                            duration=500,
-                            loop=0,
-                        )
+                rows.append(features)
             except Exception as e:  # pragma: no cover - defensive
                 logger.error(f"Analysis failed for {self.patient_id} - {session_id}: {e}", exc_info=True)
-                continue
+                raise
 
         df = pd.DataFrame(rows) if rows else pd.DataFrame()
         self.results = df
@@ -607,7 +580,7 @@ class P300OddballPipeline(BasePipeline):
                 data_1,
                 info=epochs35.info.copy(),
                 tmin=tmin,
-                baseline=ERP_CONFIG["baseline"],
+                baseline=None,
                 verbose=False,
             )
             placeholder.drop([0], reason="PLACEHOLDER")
@@ -618,11 +591,53 @@ class P300OddballPipeline(BasePipeline):
             data,
             info=epochs35.info.copy(),
             tmin=tmin,
-            baseline=ERP_CONFIG["baseline"],
+            baseline=None,
             verbose=False,
         )
         logger.info(f"Extracted {len(sub_epochs)} sub-epochs from ENG-03 35s trials")
         return sub_epochs
+
+    def _apply_official_filters(self, epochs: mne.Epochs) -> mne.Epochs:
+        """Apply the oddball-official filter stack and then baseline-correct."""
+        if len(epochs) == 0:
+            return epochs.copy()
+
+        sfreq = float(epochs.info["sfreq"])
+        eeg_picks = mne.pick_types(epochs.info, eeg=True, meg=False, exclude=[])
+        filtered_data = np.array(epochs.get_data(), copy=True)
+
+        notch_freq_hz = ODDBALL_FILTER_CONFIG["notch_freq_hz"]
+        if notch_freq_hz is not None and len(eeg_picks) > 0 and notch_freq_hz < (sfreq / 2.0):
+            filtered_data[:, eeg_picks, :] = mne.filter.notch_filter(
+                filtered_data[:, eeg_picks, :],
+                Fs=sfreq,
+                freqs=[notch_freq_hz],
+                method=ODDBALL_FILTER_CONFIG["filter_method"],
+                verbose=False,
+            )
+
+        lowpass_freq_hz = ODDBALL_FILTER_CONFIG["lowpass_freq_hz"]
+        if lowpass_freq_hz is not None and len(eeg_picks) > 0 and lowpass_freq_hz < (sfreq / 2.0):
+            filtered_data[:, eeg_picks, :] = mne.filter.filter_data(
+                filtered_data[:, eeg_picks, :],
+                sfreq=sfreq,
+                l_freq=None,
+                h_freq=lowpass_freq_hz,
+                method=ODDBALL_FILTER_CONFIG["filter_method"],
+                verbose=False,
+            )
+
+        filtered_epochs = mne.EpochsArray(
+            filtered_data,
+            info=epochs.info.copy(),
+            tmin=epochs.tmin,
+            baseline=None,
+            verbose=False,
+        )
+        if epochs.metadata is not None:
+            filtered_epochs.metadata = epochs.metadata.copy()
+        filtered_epochs.apply_baseline(ERP_CONFIG["baseline"])
+        return filtered_epochs
 
     # ------------------------------------------------------------------
     # ERP computation and P300 quantification
@@ -1099,6 +1114,102 @@ class P300OddballPipeline(BasePipeline):
         qc_df = self._build_mapping_qc_table(patient_id, session_id, features)
 
         self._update_master_feature_tables(clinical_df, detail_df, qc_df)
+
+    def _session_plot_paths(self, patient_id: str, session_id: str) -> Dict[str, Path]:
+        """Return the oddball plot artifact paths for one session."""
+        sid = self._sanitize_session_id(session_id)
+        base = f"{patient_id}_{sid}_oddball"
+        return {
+            "p300": self._output_paths.plots_erp / f"{base}_p300.png",
+            "mmn": self._output_paths.plots_erp / f"{base}_mmn.png",
+            "erp": self._output_paths.plots_erp / f"{base}_erp.png",
+            "erp_image": self._output_paths.plots_erp / f"{base}_erp_image.png",
+            "topomap": self._output_paths.plots_erp / f"{base}_topomap.png",
+            "topomap_gif": self._output_paths.plots_erp / f"{base}_topomap.gif",
+        }
+
+    @staticmethod
+    def _delete_plot_artifacts(paths: Dict[str, Path]) -> None:
+        """Delete any existing plot artifacts for a session."""
+        for path in paths.values():
+            if path.exists():
+                path.unlink()
+
+    def _generate_session_plots(
+        self,
+        patient_id: str,
+        session_id: str,
+        session: SessionData,
+        features: Dict[str, Any],
+    ) -> None:
+        """Generate the oddball plot set, failing the run if required artifacts cannot be written."""
+        if (
+            session.epochs is None
+            or session.rare_erp is None
+            or session.rare_sem is None
+            or session.standard_erp is None
+            or session.standard_sem is None
+            or session.diff_erp is None
+        ):
+            raise RuntimeError(
+                f"Missing ERP inputs required for oddball plot export: {patient_id} {session_id}",
+            )
+
+        plot_paths = self._session_plot_paths(patient_id, session_id)
+        self._delete_plot_artifacts(plot_paths)
+
+        label = f"{patient_id} | {session_id}" + (f" ({session.date})" if session.date else "")
+
+        try:
+            fig_p300 = self.viz.plot_p300_focus(
+                rare_erp=session.rare_erp,
+                standard_erp=session.standard_erp,
+                diff_erp=session.diff_erp,
+                features=features,
+                label=label,
+            )
+            self._save_fig(fig_p300, plot_paths["p300"])
+
+            fig_mmn = self.viz.plot_mmn_focus(
+                rare_erp=session.rare_erp,
+                standard_erp=session.standard_erp,
+                diff_erp=session.diff_erp,
+                features=features,
+                label=label,
+            )
+            self._save_fig(fig_mmn, plot_paths["mmn"])
+
+            fig_erp = self.viz.plot_erp_figure(
+                session.rare_erp,
+                session.rare_sem,
+                session.standard_erp,
+                session.standard_sem,
+                session.diff_erp,
+                features,
+                label,
+            )
+            self._save_fig(fig_erp, plot_paths["erp"])
+
+            fig_img = self.viz.plot_erp_image(session.epochs, label)
+            if fig_img is not None:
+                self._save_fig(fig_img, plot_paths["erp_image"])
+
+            fig_topo = self.viz.plot_topomap(session.diff_erp, label)
+            self._save_fig(fig_topo, plot_paths["topomap"])
+
+            anim_topo = self.viz.animate_topomap(session.diff_erp, label)
+            if not anim_topo:
+                raise RuntimeError(f"Topomap animation produced no frames for {patient_id} {session_id}")
+            anim_topo[0].save(
+                plot_paths["topomap_gif"],
+                save_all=True,
+                append_images=anim_topo[1:],
+                duration=500,
+                loop=0,
+            )
+        except Exception:
+            self._delete_plot_artifacts(plot_paths)
+            raise
 
     @staticmethod
     def _save_fig(fig: plt.Figure, path: Path) -> Path:

--- a/src/pipelines/p300_oddball.py
+++ b/src/pipelines/p300_oddball.py
@@ -46,9 +46,8 @@ ERP_CONFIG = {
 }
 
 ODDBALL_FILTER_CONFIG = {
-    # Temporarily using 60 Hz notch only so we can judge its isolated effect on oddball outputs.
-    "notch_freq_hz": 60.0,
-    "lowpass_freq_hz": None,
+    # Official oddball smoothing path: 30 Hz low-pass only.
+    "lowpass_freq_hz": 30.0,
     "filter_method": "iir",
 }
 
@@ -605,16 +604,6 @@ class P300OddballPipeline(BasePipeline):
         sfreq = float(epochs.info["sfreq"])
         eeg_picks = mne.pick_types(epochs.info, eeg=True, meg=False, exclude=[])
         filtered_data = np.array(epochs.get_data(), copy=True)
-
-        notch_freq_hz = ODDBALL_FILTER_CONFIG["notch_freq_hz"]
-        if notch_freq_hz is not None and len(eeg_picks) > 0 and notch_freq_hz < (sfreq / 2.0):
-            filtered_data[:, eeg_picks, :] = mne.filter.notch_filter(
-                filtered_data[:, eeg_picks, :],
-                Fs=sfreq,
-                freqs=[notch_freq_hz],
-                method=ODDBALL_FILTER_CONFIG["filter_method"],
-                verbose=False,
-            )
 
         lowpass_freq_hz = ODDBALL_FILTER_CONFIG["lowpass_freq_hz"]
         if lowpass_freq_hz is not None and len(eeg_picks) > 0 and lowpass_freq_hz < (sfreq / 2.0):

--- a/src/reports/oddball_report.py
+++ b/src/reports/oddball_report.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import math
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -37,9 +38,16 @@ class OddballQCReport:
         self.clinical_row = clinical_row
         self.detail_df = detail_df
         self.mapping_row = mapping_row
-        self.output_dir = output_dir or (config.REPORTS_DIR / patient_id / session_id / "oddball")
-        self.output_dir = Path(self.output_dir)
-        self.report_file = self.output_dir / f"{session_id}_oddball_qc.html"
+        self._setup_output_dir(output_dir)
+
+    def _setup_output_dir(self, output_dir: Optional[Path]) -> None:
+        """Setup a timestamped session report directory unless one is provided explicitly."""
+        if output_dir is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            output_dir = config.REPORTS_DIR / self.patient_id / self.session_id / "oddball" / timestamp
+
+        self.output_dir = Path(output_dir)
+        self.report_file = self.output_dir / "oddball_qc.html"
 
     def build_session_html(self) -> str:
         """Collapsible <details> fragment for the combined report (used by runner)."""
@@ -660,7 +668,6 @@ class OddballQCReport:
         labels = {
             "p300": "P300 Focus (Pz)",
             "mmn": "MMN Focus (Fz)",
-            "erp": "ERP Waveforms",
             "topomap": "Scalp Topography (Difference Wave)",
             "erp_image": "Single-Trial ERP Image (Pz)",
         }
@@ -688,11 +695,10 @@ class OddballQCReport:
 
         row_p300 = card_full("p300")
         row_mmn = card_full("mmn")
-        row_erp = card_full("erp") if not row_p300 and not row_mmn else ""
         row3_parts = [card(k) for k in ("topomap", "erp_image") if card(k)]
         row3 = f"<div class='plot-row'>\n{''.join(row3_parts)}\n</div>" if row3_parts else ""
 
-        return f"{row_p300}\n{row_mmn}\n{row_erp}\n{row3}"
+        return f"{row_p300}\n{row_mmn}\n{row3}"
 
     def _resolve_plot_paths(self) -> Dict[str, Optional[str]]:
         """Return base64-encoded data URIs for plot PNGs/GIFs so images are embedded inline."""

--- a/src/reports/oddball_report.py
+++ b/src/reports/oddball_report.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 import math
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 

--- a/src/viz/oddball_viz.py
+++ b/src/viz/oddball_viz.py
@@ -307,10 +307,12 @@ class OddballVisualizer:
         if annotation_latency_ms is not None:
             time_midpoint_ms = 0.5 * (times_ms[0] + times_ms[-1])
             if annotation_latency_ms >= time_midpoint_ms:
-                annotation_kwargs.update({
-                    "xytext": (-12, 14),
-                    "ha": "right",
-                })
+                annotation_kwargs.update(
+                    {
+                        "xytext": (-12, 14),
+                        "ha": "right",
+                    }
+                )
 
         if annotation_latency_ms is not None and annotation_amplitude_uv is not None:
             ax.axvline(

--- a/src/viz/oddball_viz.py
+++ b/src/viz/oddball_viz.py
@@ -241,6 +241,160 @@ class OddballVisualizer:
         fig.tight_layout(pad=1.5, h_pad=2.0)
         return fig
 
+    @staticmethod
+    def _get_channel_trace(evoked: mne.Evoked, electrode: str) -> tuple[np.ndarray, np.ndarray]:
+        """Return time (ms) and amplitude (uV) for one electrode."""
+        electrode_upper = electrode.upper()
+        ch_names_upper = [ch.upper() for ch in evoked.ch_names]
+        if electrode_upper not in ch_names_upper:
+            raise ValueError(f"Electrode {electrode} not found in evoked channels")
+        ch_idx = ch_names_upper.index(electrode_upper)
+        return evoked.times * 1000.0, evoked.data[ch_idx, :] * 1e6
+
+    def _plot_focus_figure(
+        self,
+        rare_erp: mne.Evoked,
+        standard_erp: mne.Evoked,
+        diff_erp: mne.Evoked,
+        label: str,
+        *,
+        electrode: str,
+        title: str,
+        window_ms: tuple[float, float],
+        window_label: str,
+        annotation_latency_ms: Optional[float],
+        annotation_amplitude_uv: Optional[float],
+        annotation_color: str,
+        annotation_prefix: str,
+    ) -> plt.Figure:
+        """Render a single-electrode focus plot for the official oddball outputs."""
+        times_ms, rare_trace = self._get_channel_trace(rare_erp, electrode)
+        _, standard_trace = self._get_channel_trace(standard_erp, electrode)
+        _, diff_trace = self._get_channel_trace(diff_erp, electrode)
+
+        fig, ax = plt.subplots(figsize=(12, 5))
+        ax.plot(times_ms, rare_trace, color="blue", linewidth=2.0, label="Rare")
+        ax.plot(times_ms, standard_trace, color="gray", linewidth=1.8, linestyle="--", label="Standard")
+        ax.plot(times_ms, diff_trace, color="green", linewidth=2.2, label="Difference (Rare - Std)")
+
+        ax.axvline(x=0.0, color="black", linestyle="--", linewidth=1.2)
+        ax.axhline(y=0.0, color="gray", linestyle=":", linewidth=1.0)
+        ax.axvspan(window_ms[0], window_ms[1], alpha=0.18, color="green", label=title.split()[0] + " Window")
+        ax.set_xlabel("Time (ms)")
+        ax.set_ylabel("Amplitude (uV)")
+        ax.set_title(title)
+        ax.grid(True, alpha=0.25)
+
+        y_min, y_max = ax.get_ylim()
+        window_center_ms = 0.5 * (window_ms[0] + window_ms[1])
+        ax.text(
+            window_center_ms,
+            y_max - 0.06 * (y_max - y_min),
+            window_label,
+            ha="center",
+            va="top",
+            fontsize=9,
+            color="darkgreen",
+            fontweight="bold",
+            bbox=dict(boxstyle="round,pad=0.25", facecolor="white", alpha=0.85, edgecolor="green"),
+        )
+
+        annotation_kwargs = {
+            "xytext": (12, 14),
+            "ha": "left",
+            "va": "bottom",
+        }
+        if annotation_latency_ms is not None:
+            time_midpoint_ms = 0.5 * (times_ms[0] + times_ms[-1])
+            if annotation_latency_ms >= time_midpoint_ms:
+                annotation_kwargs.update({
+                    "xytext": (-12, 14),
+                    "ha": "right",
+                })
+
+        if annotation_latency_ms is not None and annotation_amplitude_uv is not None:
+            ax.axvline(
+                x=annotation_latency_ms,
+                color=annotation_color,
+                linestyle="--",
+                linewidth=1.6,
+                alpha=0.75,
+            )
+            ax.scatter(
+                [annotation_latency_ms],
+                [annotation_amplitude_uv],
+                color=annotation_color,
+                s=120,
+                zorder=5,
+                marker="^" if annotation_amplitude_uv >= 0 else "v",
+            )
+            ax.annotate(
+                f"{annotation_prefix}: {annotation_amplitude_uv:.2f}uV\n@ {annotation_latency_ms:.0f}ms",
+                xy=(annotation_latency_ms, annotation_amplitude_uv),
+                xytext=annotation_kwargs["xytext"],
+                textcoords="offset points",
+                fontsize=10,
+                fontweight="bold",
+                ha=annotation_kwargs["ha"],
+                va=annotation_kwargs["va"],
+                color=annotation_color,
+                bbox=dict(boxstyle="round,pad=0.3", facecolor="white", alpha=0.9, edgecolor=annotation_color),
+                arrowprops=dict(arrowstyle="->", color=annotation_color),
+            )
+
+        ax.legend(loc="upper right")
+        fig.suptitle(label, fontsize=10, y=0.98)
+        fig.tight_layout()
+        return fig
+
+    def plot_p300_focus(
+        self,
+        rare_erp: mne.Evoked,
+        standard_erp: mne.Evoked,
+        diff_erp: mne.Evoked,
+        features: Dict[str, Any],
+        label: str,
+    ) -> plt.Figure:
+        """Pz-focused P300 waveform view used by the main oddball report."""
+        return self._plot_focus_figure(
+            rare_erp=rare_erp,
+            standard_erp=standard_erp,
+            diff_erp=diff_erp,
+            label=label,
+            electrode="Pz",
+            title="P300 Focus (Pz)",
+            window_ms=(300.0, 600.0),
+            window_label="P300 Window\n300-600 ms",
+            annotation_latency_ms=features.get("p300_latency_Pz_ms"),
+            annotation_amplitude_uv=features.get("p300_amplitude_Pz_uV"),
+            annotation_color="blue",
+            annotation_prefix="P300 Candidate",
+        )
+
+    def plot_mmn_focus(
+        self,
+        rare_erp: mne.Evoked,
+        standard_erp: mne.Evoked,
+        diff_erp: mne.Evoked,
+        features: Dict[str, Any],
+        label: str,
+    ) -> plt.Figure:
+        """Fz-focused MMN waveform view used by the main oddball report."""
+        return self._plot_focus_figure(
+            rare_erp=rare_erp,
+            standard_erp=standard_erp,
+            diff_erp=diff_erp,
+            label=label,
+            electrode="Fz",
+            title="MMN Focus (Fz)",
+            window_ms=(100.0, 250.0),
+            window_label="MMN Window\n100-250 ms",
+            annotation_latency_ms=features.get("diff_mmn_latency_Fz_ms"),
+            annotation_amplitude_uv=features.get("diff_mmn_amplitude_Fz_uV"),
+            annotation_color="purple",
+            annotation_prefix="MMN Diff",
+        )
+
     def plot_erp_image(self, epochs: mne.Epochs, label: str) -> Optional[plt.Figure]:
         """Single-trial ERP image at Pz.
 

--- a/tasks/ENG-02.md
+++ b/tasks/ENG-02.md
@@ -56,3 +56,9 @@ Implemented timestamp alignment to synchronize experimental event logs (stimuli)
    - It compares the EDF start timestamp (converted to unix) with the first trial's start timestamp.
    - If the difference is greater than 1 hour, it rounds to the nearest hour and applies it as a correction.
    - **Note**: This logic is simplistic but sufficient for our current data. Corner cases (DST changes, etc.) would result in **failed alignment** (0 correlation) rather than incorrect data, so they are easily detectable if they occur.
+
+## Downstream Oddball Note
+
+- During oddball ERP smoothing checks on `2026-03-13`, a `60 Hz` notch filter was compared against a `30 Hz` low-pass-only path.
+- Result: the notch produced little to no visible change in the final oddball plots once the `30 Hz` low-pass was already applied.
+- Current oddball branch decision: keep the `60 Hz` notch disabled and use the `30 Hz` low-pass for the official oddball output path.

--- a/tests/test_oddball_report.py
+++ b/tests/test_oddball_report.py
@@ -1,9 +1,11 @@
 """Tests for OddballQCReport (parquet-based oddball QC HTML)."""
 
+from datetime import datetime as real_datetime
 import math
 
 import pandas as pd
 
+from src.data_loading import config
 from src.reports.oddball_report import OddballQCReport
 
 
@@ -235,7 +237,7 @@ def test_generate_writes_html_file(tmp_path):
     out = report.generate()
 
     assert out.exists()
-    assert out == tmp_path / f"{session_id}_oddball_qc.html"
+    assert out == tmp_path / "oddball_qc.html"
     content = out.read_text(encoding="utf-8")
     assert "P300 Oddball Summary Report" in content
     assert "P300 Candidate at Pz" in content
@@ -245,6 +247,41 @@ def test_generate_writes_html_file(tmp_path):
     assert patient_id in content
     assert session_id in content
     assert "</html>" in content
+
+
+def test_build_plots_section_renders_focus_topomap_and_single_trial_plots(tmp_path, monkeypatch):
+    report = _make_report()
+    monkeypatch.setattr(config, "ERP_PLOTS_DIR", tmp_path)
+
+    base = f"{report.patient_id}_{report.session_id}_oddball"
+    (tmp_path / f"{base}_p300.png").write_bytes(b"p300")
+    (tmp_path / f"{base}_mmn.png").write_bytes(b"mmn")
+    (tmp_path / f"{base}_erp.png").write_bytes(b"erp")
+    (tmp_path / f"{base}_topomap.gif").write_bytes(b"GIF89a")
+    (tmp_path / f"{base}_erp_image.png").write_bytes(b"erp-image")
+
+    html = report._build_plots_section()
+
+    assert "P300 Focus (Pz)" in html
+    assert "MMN Focus (Fz)" in html
+    assert "ERP Waveforms" not in html
+    assert "Scalp Topography (Difference Wave)" in html
+    assert "Single-Trial ERP Image (Pz)" in html
+
+
+def test_default_output_dir_uses_timestamped_session_folder(tmp_path, monkeypatch):
+    class FixedDateTime:
+        @staticmethod
+        def now():
+            return real_datetime(2026, 3, 13, 18, 3, 0)
+
+    monkeypatch.setattr(config, "REPORTS_DIR", tmp_path)
+    monkeypatch.setattr("src.reports.oddball_report.datetime", FixedDateTime)
+
+    report = _make_report()
+
+    assert report.output_dir == tmp_path / "CON008" / "s_CON008_202508140000" / "oddball" / "20260313_180300"
+    assert report.report_file == report.output_dir / "oddball_qc.html"
 
 
 def test_format_cell_is_valid_icons():

--- a/tests/test_oddball_report.py
+++ b/tests/test_oddball_report.py
@@ -1,7 +1,7 @@
 """Tests for OddballQCReport (parquet-based oddball QC HTML)."""
 
-from datetime import datetime as real_datetime
 import math
+from datetime import datetime as real_datetime
 
 import pandas as pd
 

--- a/tests/test_oddball_runner.py
+++ b/tests/test_oddball_runner.py
@@ -1,0 +1,140 @@
+"""Tests for the oddball CLI runner report output path."""
+
+from datetime import datetime as real_datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from src.cli.runners import oddball as oddball_runner
+from src.data_loading import config
+
+
+def test_report_output_path_uses_timestamped_session_folder(tmp_path, monkeypatch):
+    class FixedDateTime:
+        @staticmethod
+        def now():
+            return real_datetime(2026, 3, 13, 18, 3, 0)
+
+    features_dir = tmp_path / "features"
+    features_dir.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "p300_oddball_clinical.parquet",
+        "p300_oddball_electrode_detail.parquet",
+        "p300_oddball_mapping_qc.parquet",
+    ):
+        (features_dir / name).write_text("placeholder", encoding="utf-8")
+
+    patient_id = "CON008"
+    session_id = "s_CON008_202508140000"
+
+    clinical_df = pd.DataFrame(
+        [
+            {
+                "patient_id": patient_id,
+                "session_id": session_id,
+                "session_date": "2025-08-14",
+                "n_rare_epochs": 10,
+                "n_standard_epochs": 65,
+                "baseline_std_uV": 1.89,
+                "p300_rare_amplitude_Pz_uV": 3.08,
+                "p300_rare_latency_Pz_ms": 476.56,
+                "p300_diff_amplitude_Pz_uV": 5.40,
+                "p300_diff_latency_Pz_ms": 467.0,
+                "diff_mmn_amplitude_Fz_uV": -4.36,
+                "diff_mmn_latency_Fz_ms": 152.34,
+                "p300_best_electrode": "Pz",
+                "p300_subtype": "P3b",
+                "p300_amplitude_uV": 3.90,
+                "p300_latency_ms": 430.0,
+                "p300_n_valid_electrodes": 3,
+                "qc_notes": "",
+                "qc_pass": True,
+                "p300_p_value": 0.775,
+                "p300_t_stat": 0.29,
+                "p300_n_rare": 10,
+                "p300_n_standard": 65,
+            }
+        ]
+    )
+    detail_df = pd.DataFrame(
+        [
+            {
+                "patient_id": patient_id,
+                "session_id": session_id,
+                "electrode": "Pz",
+                "p300_amplitude_uV": 4.2,
+                "p300_latency_ms": 385,
+                "is_valid": True,
+                "flagged_reason": None,
+                "diff_amplitude_uV": 5.4,
+                "diff_latency_ms": 467,
+                "diff_mmn_amplitude_uV": -1.1,
+                "diff_mmn_latency_ms": 180.0,
+            }
+        ]
+    )
+    mapping_df = pd.DataFrame(
+        [
+            {
+                "patient_id": patient_id,
+                "session_id": session_id,
+                "n_rare_events_candidate": 15,
+                "n_rare_mapped": 12,
+                "n_rare_unmapped": 2,
+                "n_rare_boundary_clipped": 1,
+                "rare_mapping_rate": 0.8,
+                "n_standard_events_candidate": 30,
+                "n_standard_mapped": 24,
+            }
+        ]
+    )
+
+    def fake_read_parquet(path: Path):
+        path = Path(path)
+        if path.name == "p300_oddball_clinical.parquet":
+            return clinical_df
+        if path.name == "p300_oddball_electrode_detail.parquet":
+            return detail_df
+        if path.name == "p300_oddball_mapping_qc.parquet":
+            return mapping_df
+        raise AssertionError(f"Unexpected parquet path: {path}")
+
+    mock_loader = MagicMock()
+    mock_patient = MagicMock()
+    mock_patient.list_session_ids.return_value = [session_id]
+    mock_loader.get_patient.return_value = mock_patient
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.run.return_value = clinical_df
+
+    captured = {}
+
+    def fake_stitch_and_save(fragments, output_path, title, generator_name, extra_css):
+        captured["output_path"] = Path(output_path)
+        captured["title"] = title
+        return Path(output_path)
+
+    monkeypatch.setattr(config, "FEATURES_DIR", features_dir)
+    monkeypatch.setattr(
+        config,
+        "REPORT_DIR_TEMPLATE",
+        str(tmp_path / "{patient_id}" / "{session_id}" / "{pipeline_name}"),
+    )
+    monkeypatch.setattr(oddball_runner, "datetime", FixedDateTime)
+    monkeypatch.setattr(oddball_runner.pd, "read_parquet", fake_read_parquet)
+    monkeypatch.setattr(oddball_runner, "P300OddballPipeline", lambda loader: mock_pipeline)
+    monkeypatch.setattr(oddball_runner, "print_table", lambda *args, **kwargs: None)
+    monkeypatch.setattr(oddball_runner.style_utils, "stitch_and_save", fake_stitch_and_save)
+    monkeypatch.setattr(oddball_runner.typer, "echo", lambda *args, **kwargs: None)
+
+    oddball_runner.run(
+        loader=mock_loader,
+        patient_ids=[patient_id],
+        session=session_id,
+        electrodes=None,
+        report=True,
+    )
+
+    assert captured["title"] == "P300 Oddball Summary — Combined Report"
+    assert captured["output_path"] == tmp_path / patient_id / session_id / "oddball" / "20260313_180300" / "oddball_qc.html"

--- a/tests/test_oddball_runner.py
+++ b/tests/test_oddball_runner.py
@@ -137,4 +137,6 @@ def test_report_output_path_uses_timestamped_session_folder(tmp_path, monkeypatc
     )
 
     assert captured["title"] == "P300 Oddball Summary — Combined Report"
-    assert captured["output_path"] == tmp_path / patient_id / session_id / "oddball" / "20260313_180300" / "oddball_qc.html"
+    assert captured["output_path"] == (
+        tmp_path / patient_id / session_id / "oddball" / "20260313_180300" / "oddball_qc.html"
+    )

--- a/tests/test_p300_oddball.py
+++ b/tests/test_p300_oddball.py
@@ -5,10 +5,12 @@ from unittest.mock import MagicMock
 import matplotlib
 
 matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 import mne
 import numpy as np
 import pandas as pd
 import pytest
+from PIL import Image
 
 from src.data_loading import config
 from src.pipelines.p300_oddball import (
@@ -130,6 +132,60 @@ def pipeline(mock_loader, temp_output_dir):
         output_dir=temp_output_dir,
         verbose=False,
     )
+
+
+def _make_small_epochs(n_epochs: int = 2, rare_scale: float = 1.0) -> mne.Epochs:
+    """Create a small oddball-like epochs object for analyze-path tests."""
+    info = mne.create_info(["Fz", "Cz", "Pz"], 512.0, "eeg")
+    data = np.zeros((n_epochs, 3, 461))
+    p300_idx = 320
+    mmn_idx = 180
+    data[:, 0, mmn_idx] = -1.5e-6 * rare_scale
+    data[:, 1, p300_idx] = 2.0e-6 * rare_scale
+    data[:, 2, p300_idx] = 3.0e-6 * rare_scale
+    return mne.EpochsArray(data, info=info, tmin=-0.2, verbose=False)
+
+
+def _make_success_session(session_id: str = "s1") -> SessionData:
+    """Create a fully populated success session for analyze-path tests."""
+    rare_epochs = _make_small_epochs(n_epochs=2, rare_scale=1.0)
+    standard_epochs = _make_small_epochs(n_epochs=2, rare_scale=0.5)
+    rare_erp = rare_epochs.average()
+    rare_sem = rare_epochs.standard_error()
+    standard_erp = standard_epochs.average()
+    standard_sem = standard_epochs.standard_error()
+    diff_erp = mne.EvokedArray(
+        rare_erp.data - standard_erp.data,
+        info=rare_erp.info.copy(),
+        tmin=rare_erp.tmin,
+        verbose=False,
+    )
+    return SessionData(
+        session_id=session_id,
+        date="2024-01-01",
+        epochs35=MagicMock(),
+        status="success",
+        epochs=rare_epochs,
+        standard_epochs=standard_epochs,
+        rare_erp=rare_erp,
+        rare_sem=rare_sem,
+        standard_erp=standard_erp,
+        standard_sem=standard_sem,
+        diff_erp=diff_erp,
+        n_standard_epochs=len(standard_epochs),
+        n_standard_events_candidate=len(standard_epochs),
+        mapping_diag={"n_mapped": 2},
+    )
+
+
+def _patch_required_plotters(monkeypatch, pipeline):
+    """Replace expensive plot generation with lightweight figures and a tiny GIF frame."""
+    monkeypatch.setattr(pipeline.viz, "plot_p300_focus", lambda *args, **kwargs: plt.figure())
+    monkeypatch.setattr(pipeline.viz, "plot_mmn_focus", lambda *args, **kwargs: plt.figure())
+    monkeypatch.setattr(pipeline.viz, "plot_erp_figure", lambda *args, **kwargs: plt.figure())
+    monkeypatch.setattr(pipeline.viz, "plot_erp_image", lambda *args, **kwargs: plt.figure())
+    monkeypatch.setattr(pipeline.viz, "plot_topomap", lambda *args, **kwargs: plt.figure())
+    monkeypatch.setattr(pipeline.viz, "animate_topomap", lambda *args, **kwargs: [Image.new("RGB", (8, 8), "white")])
 
 
 # ── Load ─────────────────────────────────────────────────────────────────────
@@ -271,6 +327,43 @@ class TestPreprocess:
         assert sess.rare_erp is not None
         assert sess.epochs is not None
         assert len(sess.epochs) >= ERP_CONFIG["min_epochs"]
+
+    def test_apply_official_filters_uses_notch_and_baseline_when_lowpass_disabled(
+        self, pipeline, mock_eng03_epochs, monkeypatch
+    ):
+        tw = pipeline._build_trial_windows(mock_eng03_epochs)
+        trial_start = tw["start_time_unix"].iloc[0]
+        events = [{"timestamp_unix": trial_start + 10.0, "date": "2024-01-01", "trial_idx": 0}]
+        mapped_df, _ = pipeline._map_events_to_trials(events, tw, sfreq=float(mock_eng03_epochs.info["sfreq"]))
+        sub = pipeline._extract_subepochs(mock_eng03_epochs, mapped_df)
+
+        calls = {}
+
+        def fake_notch(data, Fs, freqs, method, verbose):
+            calls["notch"] = {"Fs": Fs, "freqs": tuple(freqs), "method": method, "shape": data.shape}
+            return data + 1.0
+
+        def fake_lowpass(data, sfreq, l_freq, h_freq, method, verbose):
+            calls["lowpass"] = {
+                "sfreq": sfreq,
+                "l_freq": l_freq,
+                "h_freq": h_freq,
+                "method": method,
+                "shape": data.shape,
+            }
+            return data * 2.0
+
+        monkeypatch.setattr(mne.filter, "notch_filter", fake_notch)
+        monkeypatch.setattr(mne.filter, "filter_data", fake_lowpass)
+
+        filtered = pipeline._apply_official_filters(sub)
+
+        assert calls["notch"]["freqs"] == (60.0,)
+        assert calls["notch"]["method"] == "iir"
+        assert "lowpass" not in calls
+        baseline_mask = (filtered.times >= ERP_CONFIG["tmin"]) & (filtered.times <= 0.0)
+        baseline_means = filtered.get_data()[:, :, baseline_mask].mean(axis=-1)
+        assert np.allclose(baseline_means, 0.0, atol=1e-12)
 
 
 # ── Event extraction and mapping ─────────────────────────────────────────────
@@ -447,23 +540,10 @@ class TestP300QuantificationAndValidation:
 
 
 class TestAnalyzeAndRun:
-    def test_analyze_skips_non_success_sessions(self, pipeline, mock_loader, temp_output_dir, mock_evoked):
+    def test_analyze_skips_non_success_sessions(self, pipeline, monkeypatch):
         pipeline.patient_id = "P01"
         pipeline._oddball_trials = pd.DataFrame([{"session_id": "s1", "date": "2024-01-01"}])
-        sess_success = SessionData(
-            session_id="s1",
-            date="2024-01-01",
-            epochs35=MagicMock(),
-            status="success",
-            rare_erp=mock_evoked,
-            epochs=mne.EpochsArray(
-                np.zeros((2, 3, 461)),
-                mne.create_info(["Fz", "Cz", "Pz"], 512, "eeg"),
-                tmin=-0.2,
-                verbose=False,
-            ),
-            mapping_diag={"n_mapped": 2},
-        )
+        sess_success = _make_success_session("s1")
         sess_fail = SessionData(
             session_id="s2",
             date="2024-01-02",
@@ -471,15 +551,196 @@ class TestAnalyzeAndRun:
             status="insufficient_epochs",
         )
         pipeline._session_data = {"s1": sess_success, "s2": sess_fail}
+        _patch_required_plotters(monkeypatch, pipeline)
+        monkeypatch.setattr(pipeline, "_save_outputs", lambda **kwargs: None)
 
         df = pipeline.analyze()
 
         assert len(df) == 1
         assert df.iloc[0]["session_id"] == "s1"
 
-    def test_run_returns_dataframe(self, pipeline, mock_loader, aligned_oddball_df, mock_eng03_epochs):
+    def test_analyze_uses_session_objects_for_stats_features_and_saved_outputs(self, pipeline, monkeypatch):
+        pipeline.patient_id = "P01"
+        session = _make_success_session("s1")
+        pipeline._session_data = {"s1": session}
+
+        expected_features = {
+            "patient_id": "P01",
+            "session_id": "s1",
+            "date": "2024-01-01",
+            "n_epochs": len(session.epochs),
+            "p300_amplitude_uV": 3.0,
+            "p300_latency_ms": 400.0,
+            "p300_amplitude_Pz_uV": 3.0,
+            "p300_latency_Pz_ms": 400.0,
+            "diff_amplitude_Pz_uV": 2.5,
+            "diff_latency_Pz_ms": 450.0,
+            "diff_mmn_amplitude_Fz_uV": -1.0,
+            "diff_mmn_latency_Fz_ms": 150.0,
+            "p300_n_valid_electrodes": 3,
+            "p300_subtype": "P3b",
+            "qc_notes": "ok",
+        }
+
+        def fake_sig(rare_epochs, standard_epochs):
+            assert rare_epochs is session.epochs
+            assert standard_epochs is session.standard_epochs
+            return {
+                "p300_p_value": 0.04,
+                "p300_t_stat": 2.1,
+                "p300_n_rare": len(rare_epochs),
+                "p300_n_standard": len(standard_epochs),
+            }
+
+        def fake_quantify(
+            erp,
+            patient_id,
+            session_id,
+            date,
+            n_epochs,
+            custom_electrodes=None,
+            diff_erp=None,
+            n_standard_epochs=None,
+            n_standard_events_candidate=None,
+        ):
+            assert erp is session.rare_erp
+            assert diff_erp is session.diff_erp
+            assert patient_id == "P01"
+            assert session_id == "s1"
+            assert date == "2024-01-01"
+            assert n_epochs == len(session.epochs)
+            assert n_standard_epochs == len(session.standard_epochs)
+            assert n_standard_events_candidate == len(session.standard_epochs)
+            return expected_features.copy()
+
+        def fake_save_outputs(patient_id, session_id, epochs, erp, features, standard_erp=None, diff_erp=None):
+            assert patient_id == "P01"
+            assert session_id == "s1"
+            assert epochs is session.epochs
+            assert erp is session.rare_erp
+            assert standard_erp is session.standard_erp
+            assert diff_erp is session.diff_erp
+            assert features["p300_p_value"] == 0.04
+
+        monkeypatch.setattr(pipeline, "_compute_p300_significance", fake_sig)
+        monkeypatch.setattr(pipeline, "_quantify_p300", fake_quantify)
+        monkeypatch.setattr(pipeline, "_save_outputs", fake_save_outputs)
+        _patch_required_plotters(monkeypatch, pipeline)
+
+        df = pipeline.analyze()
+
+        assert len(df) == 1
+        assert df.iloc[0]["session_id"] == "s1"
+        assert df.iloc[0]["p300_p_value"] == 0.04
+
+    def test_analyze_writes_required_plots_including_erp_image(self, pipeline, monkeypatch):
+        pipeline.patient_id = "P01"
+        session = _make_success_session("s1")
+        pipeline._session_data = {"s1": session}
+
+        stale_paths = pipeline._session_plot_paths("P01", "s1")
+        for path in stale_paths.values():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"stale")
+
+        monkeypatch.setattr(
+            pipeline,
+            "_compute_p300_significance",
+            lambda rare_epochs, standard_epochs: {
+                "p300_p_value": 0.04,
+                "p300_t_stat": 2.0,
+                "p300_n_rare": len(rare_epochs),
+                "p300_n_standard": len(standard_epochs),
+            },
+        )
+        monkeypatch.setattr(
+            pipeline,
+            "_quantify_p300",
+            lambda *args, **kwargs: {
+                "patient_id": "P01",
+                "session_id": "s1",
+                "date": "2024-01-01",
+                "n_epochs": len(session.epochs),
+                "p300_amplitude_uV": 3.0,
+                "p300_latency_ms": 400.0,
+                "p300_amplitude_Pz_uV": 3.0,
+                "p300_latency_Pz_ms": 400.0,
+                "diff_amplitude_Pz_uV": 2.5,
+                "diff_latency_Pz_ms": 450.0,
+                "diff_mmn_amplitude_Fz_uV": -1.0,
+                "diff_mmn_latency_Fz_ms": 150.0,
+                "p300_n_valid_electrodes": 3,
+                "p300_subtype": "P3b",
+                "qc_notes": "ok",
+                "n_standard_epochs": len(session.standard_epochs),
+            },
+        )
+        monkeypatch.setattr(pipeline, "_save_outputs", lambda **kwargs: None)
+        _patch_required_plotters(monkeypatch, pipeline)
+
+        pipeline.analyze()
+
+        assert stale_paths["p300"].exists()
+        assert stale_paths["mmn"].exists()
+        assert stale_paths["erp"].exists()
+        assert stale_paths["erp_image"].exists()
+        assert stale_paths["topomap"].exists()
+        assert stale_paths["topomap_gif"].exists()
+
+    def test_analyze_deletes_stale_plots_and_fails_hard_on_plot_error(self, pipeline, monkeypatch):
+        pipeline.patient_id = "P01"
+        session = _make_success_session("s1")
+        pipeline._session_data = {"s1": session}
+
+        stale_paths = pipeline._session_plot_paths("P01", "s1")
+        for path in stale_paths.values():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"stale")
+
+        monkeypatch.setattr(
+            pipeline,
+            "_compute_p300_significance",
+            lambda rare_epochs, standard_epochs: {
+                "p300_p_value": 0.04,
+                "p300_t_stat": 2.0,
+                "p300_n_rare": len(rare_epochs),
+                "p300_n_standard": len(standard_epochs),
+            },
+        )
+        monkeypatch.setattr(
+            pipeline,
+            "_quantify_p300",
+            lambda *args, **kwargs: {
+                "patient_id": "P01",
+                "session_id": "s1",
+                "date": "2024-01-01",
+                "n_epochs": len(session.epochs),
+                "p300_amplitude_uV": 3.0,
+                "p300_latency_ms": 400.0,
+                "p300_amplitude_Pz_uV": 3.0,
+                "p300_latency_Pz_ms": 400.0,
+                "diff_amplitude_Pz_uV": 2.5,
+                "diff_latency_Pz_ms": 450.0,
+                "diff_mmn_amplitude_Fz_uV": -1.0,
+                "diff_mmn_latency_Fz_ms": 150.0,
+                "p300_n_valid_electrodes": 3,
+                "p300_subtype": "P3b",
+                "qc_notes": "ok",
+            },
+        )
+        monkeypatch.setattr(pipeline, "_save_outputs", lambda **kwargs: None)
+        monkeypatch.setattr(pipeline.viz, "plot_p300_focus", lambda *args, **kwargs: plt.figure())
+        monkeypatch.setattr(pipeline.viz, "plot_mmn_focus", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("plot failed")))
+
+        with pytest.raises(RuntimeError, match="plot failed"):
+            pipeline.analyze()
+
+        assert all(not path.exists() for path in stale_paths.values())
+
+    def test_run_returns_dataframe(self, pipeline, mock_loader, aligned_oddball_df, mock_eng03_epochs, monkeypatch):
         mock_loader.load_aligned_events.return_value = aligned_oddball_df
         mock_loader.load_clean_epochs.return_value = mock_eng03_epochs
+        _patch_required_plotters(monkeypatch, pipeline)
 
         result = pipeline.run("P01")
 
@@ -488,9 +749,10 @@ class TestAnalyzeAndRun:
         assert "session_id" in result.columns
         assert "p300_amplitude_uV" in result.columns or "p300_amplitude_Pz_uV" in result.columns
 
-    def test_run_custom_electrodes(self, pipeline, mock_loader, aligned_oddball_df, mock_eng03_epochs):
+    def test_run_custom_electrodes(self, pipeline, mock_loader, aligned_oddball_df, mock_eng03_epochs, monkeypatch):
         mock_loader.load_aligned_events.return_value = aligned_oddball_df
         mock_loader.load_clean_epochs.return_value = mock_eng03_epochs
+        _patch_required_plotters(monkeypatch, pipeline)
 
         result = pipeline.run("P01", custom_electrodes=["Pz", "Cz"])
 
@@ -762,6 +1024,51 @@ class TestPlotting:
         pipeline._save_fig(fig, plot_path)
         assert plot_path.exists()
         assert plot_path.stat().st_size > 0
+
+    def test_plot_p300_focus(self, pipeline, mock_evoked):
+        features = {
+            "p300_amplitude_Pz_uV": 2.49,
+            "p300_latency_Pz_ms": 471.0,
+        }
+        label = "P01 | s1 (2024-01-01)"
+        fig = pipeline.viz.plot_p300_focus(
+            rare_erp=mock_evoked,
+            standard_erp=mock_evoked,
+            diff_erp=mock_evoked,
+            features=features,
+            label=label,
+        )
+        axis_texts = [text.get_text() for text in fig.axes[0].texts]
+        plot_text = " ".join(axis_texts)
+        annotation = next(text for text in fig.axes[0].texts if "P300 Candidate" in text.get_text())
+        plot_path = pipeline._output_paths.plots_erp / "P01_s1_oddball_p300.png"
+        pipeline._save_fig(fig, plot_path)
+        assert plot_path.exists()
+        assert plot_path.stat().st_size > 0
+        assert "P300 Candidate" in plot_text
+        assert "2.49uV" in plot_text
+        assert "300-600 ms" in plot_text
+        assert annotation.get_ha() == "right"
+
+    def test_plot_mmn_focus(self, pipeline, mock_evoked):
+        features = {
+            "diff_mmn_amplitude_Fz_uV": -2.5,
+            "diff_mmn_latency_Fz_ms": 150.0,
+        }
+        label = "P01 | s1 (2024-01-01)"
+        fig = pipeline.viz.plot_mmn_focus(
+            rare_erp=mock_evoked,
+            standard_erp=mock_evoked,
+            diff_erp=mock_evoked,
+            features=features,
+            label=label,
+        )
+        plot_text = " ".join(text.get_text() for text in fig.axes[0].texts)
+        plot_path = pipeline._output_paths.plots_erp / "P01_s1_oddball_mmn.png"
+        pipeline._save_fig(fig, plot_path)
+        assert plot_path.exists()
+        assert plot_path.stat().st_size > 0
+        assert "100-250 ms" in plot_text
 
     def test_plot_erp_image(self, pipeline, temp_output_dir, mock_evoked):
         # Need >= 3 epochs or plot_erp_image returns None

--- a/tests/test_p300_oddball.py
+++ b/tests/test_p300_oddball.py
@@ -328,9 +328,7 @@ class TestPreprocess:
         assert sess.epochs is not None
         assert len(sess.epochs) >= ERP_CONFIG["min_epochs"]
 
-    def test_apply_official_filters_uses_notch_and_baseline_when_lowpass_disabled(
-        self, pipeline, mock_eng03_epochs, monkeypatch
-    ):
+    def test_apply_official_filters_uses_lowpass_and_baseline(self, pipeline, mock_eng03_epochs, monkeypatch):
         tw = pipeline._build_trial_windows(mock_eng03_epochs)
         trial_start = tw["start_time_unix"].iloc[0]
         events = [{"timestamp_unix": trial_start + 10.0, "date": "2024-01-01", "trial_idx": 0}]
@@ -358,9 +356,9 @@ class TestPreprocess:
 
         filtered = pipeline._apply_official_filters(sub)
 
-        assert calls["notch"]["freqs"] == (60.0,)
-        assert calls["notch"]["method"] == "iir"
-        assert "lowpass" not in calls
+        assert "notch" not in calls
+        assert calls["lowpass"]["h_freq"] == 30.0
+        assert calls["lowpass"]["method"] == "iir"
         baseline_mask = (filtered.times >= ERP_CONFIG["tmin"]) & (filtered.times <= 0.0)
         baseline_means = filtered.get_data()[:, :, baseline_mask].mean(axis=-1)
         assert np.allclose(baseline_means, 0.0, atol=1e-12)
@@ -730,7 +728,11 @@ class TestAnalyzeAndRun:
         )
         monkeypatch.setattr(pipeline, "_save_outputs", lambda **kwargs: None)
         monkeypatch.setattr(pipeline.viz, "plot_p300_focus", lambda *args, **kwargs: plt.figure())
-        monkeypatch.setattr(pipeline.viz, "plot_mmn_focus", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("plot failed")))
+        monkeypatch.setattr(
+            pipeline.viz,
+            "plot_mmn_focus",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("plot failed")),
+        )
 
         with pytest.raises(RuntimeError, match="plot failed"):
             pipeline.analyze()


### PR DESCRIPTION
### Summary

Refines the oddball pipeline/report flow by standardizing oddball-only filtering, restoring the focused ERP visual outputs, and moving generated reports into timestamped session folders.

### Changes Made

- Switched oddball filtering to a 30 Hz low-pass-only path with baseline correction after filtering.
- Centralized oddball plot generation and stale artifact cleanup.
- Restored focused P300, MMN, single-trial ERP image, and topomap outputs.
- Updated report rendering to use timestamped session directories and simplified the plots section.
- Added/expanded tests for filter behavior, plot generation, stale artifact cleanup, and report output paths.

### Files Changed

- src/pipelines/p300_oddball.py
- src/viz/oddball_viz.py
- src/reports/oddball_report.py
- src/cli/runners/oddball.py
- tasks/ENG-02.md
- tests/test_p300_oddball.py
- tests/test_oddball_report.py
- tests/test_oddball_runner.py